### PR TITLE
metabuild: Lock -march to corei7, and turn off -Werror (for now)

### DIFF
--- a/metaBuild.sh
+++ b/metaBuild.sh
@@ -19,7 +19,7 @@ elif [ "$1" = "build" ]; then
   elif echo "$SYSTEM_NAME" | grep -q "MINGW64_NT"; then
     # Windows specific config:
     args+=(libs_extra=psapi)
-    args+=(use_openmesh=1 openmesh_libpath=#/../OpenMesh-2.0/build/Build/lib openmesh_publiclibs='OpenMeshCore,OpenMeshTools' openmesh_include=#/../OpenMesh-2.0/src)
+    args+=(use_openmesh=1 Werror=0 arch=corei7 openmesh_libpath=#/../OpenMesh-2.0/build/Build/lib openmesh_publiclibs='OpenMeshCore,OpenMeshTools' openmesh_include=#/../OpenMesh-2.0/src)
   elif echo "$SYSTEM_NAME" | grep -q "MSYS"; then
     echo "ERROR: the MSYS shell is not supported. Please use the MinGW-w64 Win64 Shell instead."
     exit 1


### PR DESCRIPTION
For some reason, geode generates a ton of warnings. By default on windows it
builds with -Werror, which causes everything to explode.

Additionally, and along the same lines of #omco/mpir/1, geode defaults to the
'native' architecture, which can result in GCC generating assembly that is
invalid for CPUs other than the one geode was built on. This can cause Otherplan
to crash due to an illegal instruction. This patch updates metaBuild.sh to use
the corei7 architecture, which is the same specified in Otherplan's qmake
configuration.