### PR TITLE
Add surface_of_revolution and clean up a few small things

### DIFF
--- a/geode/array/Array.h
+++ b/geode/array/Array.h
@@ -553,6 +553,7 @@ template<class T,int d>   static inline const RawArray<const T> asconstarray(con
 template<class T>         static inline const RawArray<const T> asconstarray(const RawArray<T>& v)      { return v; }
 template<class T>         static inline const RawArray<const T> asconstarray(const Array<T>& v)         { return v; }
 template<class T,class A> static inline const RawArray<const T> asconstarray(const std::vector<T,A>& v) { return RawArray<const T>(v.size(),&v[0]); }
+template<class T,size_t N> static inline const RawArray<const T> asconstarray(const std::array<T,N>& a) { static_assert(N <= INT_MAX, "Size too big"); return RawArray<const T>(int(N),a.data()); }
 template<class T,class A> static inline const A&                asconstarray(const ArrayBase<T,A>& v)   { return v.derived(); }
 
 template<class T,int d> static inline       Array<T>& flat(      Array<T,d>& A) { return A.flat; }

--- a/geode/array/Array.h
+++ b/geode/array/Array.h
@@ -30,6 +30,7 @@
 #include <geode/vector/Vector.h>
 #include <geode/utility/const_cast.h>
 #include <vector>
+#include <array>
 #include <initializer_list>
 
 namespace geode {

--- a/geode/geometry/Plane.h
+++ b/geode/geometry/Plane.h
@@ -12,7 +12,7 @@ template<class T> inline Vector<T,3> normal(const Vector<T,3>& x0,const Vector<T
 {return cross(x1-x0,x2-x0).normalized();}
 
 template<class TArray> inline typename EnableForSize<3,TArray,typename TArray::Element>::type normal(const TArray& X)
-{return normal(X(0),X(1),X(2));}
+{return normal(X[0],X[1],X[2]);}
 
 template<class T>
 class Plane

--- a/geode/geometry/surface_of_revolution.cpp
+++ b/geode/geometry/surface_of_revolution.cpp
@@ -1,0 +1,116 @@
+#include <geode/geometry/surface_of_revolution.h>
+#include <geode/math/constants.h>
+namespace geode {
+
+namespace {
+struct CylinderTopology {
+  int nz; // Must be > 0
+  int na; // Must be > 1
+  bool top_closed;
+  bool bottom_closed;
+
+  bool size_valid() const { return (nz > 0) && (na > 1); }
+  bool valid(const int z, const int a) const { assert(size_valid()); return (0 <= z && z < nz) && (0 <= a && a < na); }
+
+  using VertexId = int;
+
+  VertexId side_vertex(const int z, const int a) const {
+    assert(valid(z,a));
+    return VertexId(bottom_closed + z + a*nz);
+  }
+
+  int num_side_vertices() const { return nz*na; }
+  int num_vertices() const { return num_side_vertices() + top_closed + bottom_closed; }
+  int num_faces() const { assert(size_valid()); return na*((nz-1)*2 + top_closed + bottom_closed); }
+
+  VertexId bottom_vertex() const { assert(bottom_closed); return VertexId(0); }
+  VertexId top_vertex() const { assert(top_closed); return VertexId(num_side_vertices()+bottom_closed); }
+
+  int next_a(const int a) const { return (a+1 == na) ? 0 : a+1; }
+
+  Array<Vector<VertexId,3>> faces() const {
+    Array<Vector<VertexId,3>> result;
+    result.preallocate(num_faces());
+    if(bottom_closed) {
+      const VertexId v0 = bottom_vertex();
+      for(int curr_a = 0; curr_a < na; ++curr_a) {
+        const int next_a = this->next_a(curr_a);
+        const VertexId v1 = side_vertex(0,next_a);
+        const VertexId v2 = side_vertex(0,curr_a);
+        result.append(vec(v0,v1,v2));
+      }
+    }
+    for(int z = 0; z < nz-1; ++z) {
+      for(int curr_a = 0; curr_a < na; ++curr_a) {
+        const int next_a = this->next_a(curr_a);
+        const VertexId ll = side_vertex(z+0,curr_a);
+        const VertexId lr = side_vertex(z+0,next_a);
+        const VertexId ur = side_vertex(z+1,next_a);
+        const VertexId ul = side_vertex(z+1,curr_a);
+        result.append(vec(ll,lr,ul));
+        result.append(vec(lr,ur,ul));
+      }
+    }
+    if(top_closed) {
+      const VertexId v2 = top_vertex();
+      for(int curr_a = 0; curr_a < na; ++curr_a) {
+        const int next_a = this->next_a(curr_a);
+        const VertexId v0 = side_vertex(nz-1,curr_a);
+        const VertexId v1 = side_vertex(nz-1,next_a);
+        result.append(vec(v0,v1,v2));
+      }
+    }
+    return result;
+  }
+};
+} // anonymous namespace
+
+template<class T> static T r(const Vector<T,2>& rz) { return rz.x; }
+template<class T> static T z(const Vector<T,2>& rz) { return rz.y; }
+
+// Templated version used to provide overloads for float and double
+template<class T> static Tuple<Array<Vec3i>,Array<Vector<T,3>>> surface_of_revolution_helper(RawArray<const Vector<T,2>> profile_rz, const int sides) {
+  using TV2 = Vector<T,2>;
+  using TV3 = Vector<T,3>;
+  const auto bottom_z = z(profile_rz.front());
+  const auto top_z = z(profile_rz.back());
+
+  // Trim endpoints of profile if it already tapers to a point
+  int profile_revolve_start = 0;
+  int profile_revolve_end = profile_rz.size();
+  constexpr T tolerance = 0;
+  if(profile_revolve_start < profile_rz.size() 
+        && r(profile_rz[profile_revolve_start]) <= tolerance) {
+    ++profile_revolve_start;
+  }
+  if(profile_revolve_end > 0
+        && r(profile_rz[profile_revolve_end-1]) <= tolerance) {
+    --profile_revolve_end;
+  }
+  const RawArray<const TV2> body_profile = profile_rz.slice(profile_revolve_start, profile_revolve_end);
+
+  const CylinderTopology topology = {body_profile.size(), sides, true, true};
+
+  Array<TV3> X;
+  X.preallocate(topology.num_vertices());
+  const T segment_angle = tau/sides;
+  X.append(TV3(0, 0, bottom_z));
+  for(const int i : range(sides)) {
+    const TV2 r_axis = polar(segment_angle*i);
+    for(const auto& p : body_profile)
+      X.append_assuming_enough_space(TV3(r(p)*r_axis,z(p)));
+  }
+  X.append(TV3(0,0,top_z));
+  assert(X.size() == topology.num_vertices());
+  return tuple(topology.faces(), X);
+}
+
+Tuple<Array<Vector<int,3>>,Array<Vector<float,3>>> surface_of_revolution(RawArray<const Vector<float,2>> profile_rz, const int sides) {
+  return surface_of_revolution_helper(profile_rz, sides);
+}
+
+Tuple<Array<Vector<int,3>>,Array<Vector<double,3>>> surface_of_revolution(RawArray<const Vector<double,2>> profile_rz, const int sides) {
+  return surface_of_revolution_helper(profile_rz, sides);
+}
+
+} // geode namespace

--- a/geode/geometry/surface_of_revolution.h
+++ b/geode/geometry/surface_of_revolution.h
@@ -1,0 +1,16 @@
+#pragma once
+#include <geode/array/Array.h>
+#include <geode/vector/Vector.h>
+#include <geode/structure/tuple.h>
+namespace geode {
+
+// Generates mesh by rotating profile_rz around z axis
+// Returns triangles and positions of vertices
+
+GEODE_CORE_EXPORT Tuple<Array<Vector<int,3>>,Array<Vector<float,3>>>
+    surface_of_revolution(const RawArray<const Vector<float,2>> profile_rz, const int sides);
+
+GEODE_CORE_EXPORT Tuple<Array<Vector<int,3>>,Array<Vector<double,3>>>
+    surface_of_revolution(const RawArray<const Vector<double,2>> profile_rz, const int sides);
+
+} // geode namespace

--- a/geode/math/constants.h
+++ b/geode/math/constants.h
@@ -2,6 +2,7 @@
 // Header constants
 //#####################################################################
 #pragma once
+#include <geode/config.h>
 
 #include <cmath>
 #include <limits>

--- a/geode/math/constants.h
+++ b/geode/math/constants.h
@@ -10,16 +10,16 @@ namespace geode {
 using std::numeric_limits;
 
 #ifdef _WIN32
-const double pi = 3.14159265358979323846;
+GEODE_CONSTEXPR_IF_NOT_MSVC double pi = 3.14159265358979323846;
 #else
-const double pi = M_PI;
+GEODE_CONSTEXPR_IF_NOT_MSVC double pi = M_PI;
 #endif
-const double half_pi = 0.5*pi;
-const double tau = 2*pi;
-const double speed_of_light = 2.99792458e8; // m/s
-const double plancks_constant = 6.6260755e-34; // J*s
-const double boltzmanns_constant = 1.380658e-23; // J/K
-const double ideal_gas_constant = 8.314472; // J/K/mol
+GEODE_CONSTEXPR_IF_NOT_MSVC double half_pi = 0.5*pi;
+GEODE_CONSTEXPR_IF_NOT_MSVC double tau = 2*pi;
+GEODE_CONSTEXPR_IF_NOT_MSVC double speed_of_light = 2.99792458e8; // m/s
+GEODE_CONSTEXPR_IF_NOT_MSVC double plancks_constant = 6.6260755e-34; // J*s
+GEODE_CONSTEXPR_IF_NOT_MSVC double boltzmanns_constant = 1.380658e-23; // J/K
+GEODE_CONSTEXPR_IF_NOT_MSVC double ideal_gas_constant = 8.314472; // J/K/mol
 
 const double inf = numeric_limits<double>::infinity();
 

--- a/geode/math/signed_compare.h
+++ b/geode/math/signed_compare.h
@@ -27,5 +27,4 @@ template<class SignedT, class UnsignedT> auto signed_eq(const SignedT x0, const 
 template<class UnsignedT, class SignedT> auto signed_eq(const UnsignedT x0, const SignedT x1) -> typename enable_if_c<is_unsigned<UnsignedT>::value && is_signed<SignedT>::value, bool>::type
 { return (0 <= x1) && (x0 == static_cast<typename make_unsigned<SignedT>::type>(x1)); }
 
-
 } // namespace geode

--- a/geode/python/from_python.cpp
+++ b/geode/python/from_python.cpp
@@ -2,7 +2,7 @@
 // Function from_python
 //#####################################################################
 #include <geode/python/from_python.h>
-#include <geode/utility/signed_compare.h>
+#include <geode/math/signed_compare.h>
 #include <geode/utility/format.h>
 namespace geode {
 
@@ -29,7 +29,12 @@ long FromPython<long>::convert(PyObject* object) {
   return i;
 }
 
+// TODO: This would probably be useful elsewhere and worth moving to math/signed_compare.h
+// Test if argument is in range of values that can be represented by ToT
+// Note: This doesn't have specializations for range of ToT being strictly greater than range of FromT
 template<class ToT, class FromT> static bool representable_as(const FromT x) {
+  // Make sure user isn't expecting us to check if floating point conversions require truncation or rounding
+  static_assert(std::is_integral<FromT>::value && std::is_integral<ToT>::value, "This function only supports integral types");
   return signed_leq(std::numeric_limits<ToT>::lowest(), x) && signed_leq(x, std::numeric_limits<ToT>::max());
 }
 

--- a/geode/utility/STATIC_ASSERT_SAME.h
+++ b/geode/utility/STATIC_ASSERT_SAME.h
@@ -5,7 +5,7 @@
 
 namespace geode {
 
-template<class T0,class T1> struct AssertSame;
+template<class T0,class T1> struct AssertSame { static const bool value = false; };
 template<class T> struct AssertSame<T,T> { static const bool value = true; };
 
 #define STATIC_ASSERT_SAME(T0,T1) \


### PR DESCRIPTION
 * Add surface_of_revolution. (Needs better documentation and unit tests, but works for me)
 * Add asconstarray overload to convert std::array to RawArray (Now that std::array is part of the standard library, it might be good to rename make_array, asarray, and asconstarray to something less ambiguous)
 * Make 'normal' work for Vector<Vec3,3>
 * Mark some constants as constexpr. I used GEODE_CONSTEXPR_IF_NOT_MSVC (which might no longer be needed in Visual Studio 2015), but only tested with clang
 * Have a base version of AssertSame so that static_assert is actually triggered instead of a confusing message about missing template definitions