### PR TITLE
Fix some arc csg bugs and improve related unit tests

### DIFF
--- a/geode/exact/PlanarArcGraph.h
+++ b/geode/exact/PlanarArcGraph.h
@@ -38,6 +38,9 @@ struct SignedArcInfo {
   bool is_full_circle() const { return to_vid(_head) == _tail; }
   bool positive() const { return direction() == ArcDirection::CCW; }
 };
+static inline std::ostream& operator<<(std::ostream& os, const SignedArcInfo& x) {
+  return os << "{" << x.head() << ", " << x.tail() << ", " << x.direction() << "}";
+}
 
 // To can store a sequence of signed arcs by saving start and direction, with tail implicitly specified by the start of the next arc
 struct SignedArcHead {
@@ -49,6 +52,9 @@ struct SignedArcHead {
   // ArcDirection direction() const { return arc_direction(ref_cid); }
   // IncidentId tail_iid(const SignedArcHead next_head) const { return is_same_circle(ref_cid, next_head.ref_cid) ? next_head.iid : opposite(next_head.iid); }
 };
+static inline std::ostream& operator<<(std::ostream& os, const SignedArcHead& x) {
+  return os << "{" << x.iid << ", " << x.direction << "}";
+}
 
 // Adaptor to make array of SignedArcHead behave like an array of SignedArcInfo
 struct RawArcContour {

--- a/geode/exact/circle_csg.cpp
+++ b/geode/exact/circle_csg.cpp
@@ -84,7 +84,7 @@ real circle_arc_area(RawArray<const CircleArc> arcs) {
   real area = 0;
   for (int i=n-1,j=0;j<n;i=j++)
     area += .5*cross(arcs[i].x,arcs[j].x) + .25*sqr_magnitude(arcs[j].x-arcs[i].x)*q_factor(arcs[i].q); // Triangle area plus circular sector area
-  return .5*area;
+  return area;
 }
 
 real circle_arc_area(Nested<const CircleArc> polys) {
@@ -249,6 +249,139 @@ static void random_circle_quantize_test(int seed) {
     GEODE_ASSERT(unioned.size() <= arcs.size());
   }
 }
+
+static void circle_arc_area_test() {
+  // These should return exactly zero with no rounding error
+  GEODE_ASSERT(circle_arc_area(Array<CircleArc>()) == 0.);
+  GEODE_ASSERT(circle_arc_area(Nested<CircleArc>()) == 0.);
+  const auto degenerate = make_array({CircleArc(Vec2(2.,2.),1.)});
+  // No csg functions should return an arc polygon with a single vertex, but circle_arc_area should be able to handle it
+  GEODE_ASSERT(circle_arc_area(degenerate) == 0.);
+
+  const auto area_matches = [](const real area, const real expected) -> bool {
+    constexpr real area_tolerance = 1e-9; // Maximum expected delta due to floating point rounding
+    return abs(area - expected) < area_tolerance;
+  };
+
+  // Check result for a square
+  auto unit_square = make_array({CircleArc(Vec2(0,0),0), CircleArc(Vec2(1,0),0), CircleArc(Vec2(1,1),0), CircleArc(Vec2(0,1),0)});
+  GEODE_ASSERT(area_matches(circle_arc_area(unit_square), 1.));
+  reverse_arcs(unit_square); // Should negate area
+  GEODE_ASSERT(area_matches(circle_arc_area(unit_square), -1.));
+
+  // Check circle with radius 1
+  const auto simple_circle = make_array({CircleArc(Vec2(1,0),1), CircleArc(Vec2(-1,0),1)});
+  GEODE_ASSERT(area_matches(circle_arc_area(simple_circle), pi));
+  // Offset shouldn't change area
+  for(auto& a : simple_circle) a.x += Vec2(100.,200.);
+  GEODE_ASSERT(area_matches(circle_arc_area(simple_circle), pi));
+  reverse_arcs(simple_circle); // Should negate area
+  GEODE_ASSERT(area_matches(circle_arc_area(simple_circle), -pi));
+
+  const auto make_circle = [](const int n_segments, const real radius) -> Array<CircleArc> {
+    const real segment_angle = 2.*pi / static_cast<real>(n_segments);
+    const real q = tan(0.25*segment_angle);
+    Array<CircleArc> arcs;
+    for(const int i : range(0, n_segments)) {
+      arcs.append(CircleArc(radius*polar(i*segment_angle),q));
+    }
+    return arcs;
+  };
+
+  // Check circle with different numbers of segments
+  for(const int n_segments : range(3,9)) {
+    const auto arcs = make_circle(n_segments, 1.);
+    GEODE_ASSERT(area_matches(circle_arc_area(arcs), pi));
+  }
+
+  // Try annulus with outer radius 2 and inner radius 1
+  Nested<CircleArc, false> nested_circles;
+  nested_circles.append(make_circle(3,2.));
+  nested_circles.append(make_circle(4,1.));
+  reverse_arcs(nested_circles[1]);
+  GEODE_ASSERT(area_matches(circle_arc_area(nested_circles),3.*pi));
+  reverse_arcs(nested_circles); // Check reverse_arcs on Nested
+  GEODE_ASSERT(area_matches(circle_arc_area(nested_circles),-3.*pi));
+}
+
+static real circle_arc_quantization_unit(const Nested<const CircleArc>& arcs) {
+  IntervalScope scope;
+  const auto quant = make_arc_quantizer(approximate_bounding_box(arcs));
+  return quant.inverse.unquantize_length(1.);
+}
+
+// Theoretical worst case error for any point on polyarc after round trip quantization and back assuming maximum abs(q)<=1 
+// Result is in multiples of circle_arc_quantization_unit
+// This ignores floating point rounding errors (which should be small by comparison).
+// WARNING: This is not a guarantee, only an educated guess (though it seems to hold up in testing)
+static real circle_arc_max_quantization_error_guess() {
+  // Moving ends of an arc segment moves midpoint by the same or smaller distance as long as abs(q) <= 1
+  const auto endpoint_snap_error = sqrt(0.5); // Noise added when snapping to quantized point
+  // During quantization, we compute a rational approximation of q which will differ by 1/exact::bounds from the expected value of q (assuming again that abs(q) <= 1)
+  // This approximation of q can alter midpoint by 1/2*distance_between_endpoints*delta_q
+  // The arc quantizer is chosen such that longest possible edge will be on the order of sqrt(exact::bound/8)
+  // This means approximation of q adds 1/2*sqrt(exact::bound/8)/exact::bound which will be quite small
+  const auto q_error = 1./sqrt(exact::bound/32.);
+  // Computing the center of the circle is exactly rounded using quantized endpoints and rational approximation of q so it can be off by at most sqrt(0.5)
+  const auto center_error = sqrt(0.5) + q_error;
+  // Radius is computed via distance from endpoints to center so full error from rounding center can be carried over plus an additional sqrt(0.5) error from rounding radius
+  const auto radius_error = center_error + sqrt(0.5);
+  // Rounding center further from theoretical value of arc midpoint will also increase radius which will help to stabilize position of arc midpoint
+  // This means center_error and radius_error will tend to cancel, however I can't think of a proof that rules out them adding in the worst case
+  const auto midpoint_error = endpoint_snap_error + center_error + radius_error;
+  // When going back from exact to inexact representation we add error from using the approximate intersections and from culling helper circles
+  const auto unquant_error = ApproxIntersection::tolerance() + constructed_arc_endpoint_error_bound(); // Maximum distance to constructed intersection
+  // Worst case error should be at midpoints of arcs (error at any endpoint_snap_error should be at most endpoint_snap_error + unquant_error)
+  return (midpoint_error + unquant_error);
+}
+
+// Theoretical worst case error for offset starting with exact arcs
+// Result is in multiples of circle_arc_quantization_unit
+// Add circle_arc_max_quantization_error_guess() if starting with unquantized arcs
+// WARNING: This is not a guarantee, only an educated guess
+static real circle_arc_max_offset_error_guess() {
+  // We have to round offset to a quantized value
+  const auto offset_snap_error = 0.5;
+  // Each arc in input gets expanded into a curved capsule
+  // The capsule 'sides' will be exact, but endcaps require some approximate constructions
+  // We construct endcaps centered at vertices, but we only have approximate value of intersection which we must round to a quantized value
+  const auto endcap_center_error = ApproxIntersection::tolerance() + sqrt(0.5);
+  // We have to pad radius of endcaps to ensure we get non-degenerate intersections with sides
+  const auto endcap_safety_margin = 2.;
+  // When endcaps aren't far apart enough too guarantee well behaved constructions padding gets doubled
+  const auto degenerate_endcap_padding = 2.*endcap_safety_margin;
+  // left_flags_safe is computed by comparing conservative interval distance between arc endpoints
+  // Since it's a conservative comparison it doesn't actually guarantee arc is short, however current interval implementation should be tight enough
+  // Worst case error would occur at endcaps
+  return offset_snap_error + endcap_center_error + degenerate_endcap_padding;
+}
+
+static void check_circle_quantize(const Nested<const CircleArc>& arcs0) {
+  const auto arcs1 = circle_arc_quantize_test(arcs0);
+  // Any inserted helper arcs should be culled when unquantizing so we should have one-to-one correspondence
+  // However this seems to have some failures. Maybe very small arcs in input are being culled? Needs more testing
+  if(arcs0.offsets != arcs1.offsets) {
+    // Can't directly compare arcs if offsets are different
+    // Ideally we would find what the difference is and check check correspondence on remaining arcs, but for now we just abort
+    GEODE_ASSERT(false);
+  }
+  const auto max_error = circle_arc_quantization_unit(arcs0)*circle_arc_max_quantization_error_guess();
+  // Loop over pairs of arcs and compare
+  for(const int i : range(arcs0.size())) {
+    const auto end_j = arcs0[i].size();
+    for(const int j0 : range(end_j)) {
+      const int j1 = (j0+1)%end_j;
+      const auto a0 = ArcSegment(arcs0[i][j0].x,arcs0[i][j1].x,arcs0[i][j0].q);
+      const auto a1 = ArcSegment(arcs1[i][j0].x,arcs1[i][j1].x,arcs1[i][j0].q);
+      // Check that start and end vertices are in expected error bound
+      GEODE_ASSERT((a0.x0-a1.x0).magnitude() <= max_error);
+      GEODE_ASSERT((a0.x1-a1.x1).magnitude() <= max_error);
+      // Check that midpoint of arc is in expected error bound
+      const auto midpoint_error = (a0.arc_mid()-a1.arc_mid()).magnitude();
+      GEODE_ASSERT(midpoint_error <= max_error);
+    }
+  }
+}
 #endif
 } // namespace geode
 using namespace geode;
@@ -267,5 +400,10 @@ void wrap_circle_csg() {
   GEODE_FUNCTION(circle_arc_quantize_test)
   GEODE_FUNCTION(random_circle_quantize_test)
   GEODE_FUNCTION(single_circle_handling_test)
+  GEODE_FUNCTION(circle_arc_area_test)
+  GEODE_FUNCTION(circle_arc_max_quantization_error_guess)
+  GEODE_FUNCTION(circle_arc_max_offset_error_guess)
+  GEODE_FUNCTION(circle_arc_quantization_unit)
+  GEODE_FUNCTION(check_circle_quantize)
 #endif
 }

--- a/geode/exact/circle_enums.h
+++ b/geode/exact/circle_enums.h
@@ -14,7 +14,7 @@ enum class ArcDirection : bool { CCW = false, CW = true }; // directed_edge assu
 
 // These make it easier to use ArcDirection as a winding
 inline int sign(const ArcDirection d) { return (d == ArcDirection::CCW) ? 1 : -1; }
-inline ArcDirection operator-(const ArcDirection dir) { return static_cast<ArcDirection>(dir==ArcDirection::CW); }
+inline ArcDirection operator-(const ArcDirection dir) { return static_cast<ArcDirection>(!static_cast<bool>(dir)); }
 constexpr int direction_index(const ArcDirection dir) { return static_cast<int>(dir != ArcDirection::CCW); }
 
 // CircleFace encodes if something is inside or outside of a circle

--- a/geode/exact/circle_offsets.cpp
+++ b/geode/exact/circle_offsets.cpp
@@ -48,11 +48,6 @@ static void add_capsule_helper(ArcAccumulator<Pb::Implicit>& result, const Exact
     }
   }
   else {
-    // Tolerance is for each dimension, so we need to multiply by sqrt(2) to get distance error
-    const Interval intersection_error_bound = assume_safe_sqrt(Interval(2))*ApproxIntersection::tolerance();
-    // If we grow endcap for an arc by this amount, we ensure intersection or coverage of inner and outer offset arcs
-    const Quantized endcap_safety_margin = ceil(intersection_error_bound.box().max); // Since offset circles don't need to construct new centers and have exactly correct radius, we only need to account for error of intersections
-
     const Quantized endcap_r = abs_offset + endcap_safety_margin;
 
     // Find or build circles for endcaps

--- a/geode/exact/test_circle.py
+++ b/geode/exact/test_circle.py
@@ -53,6 +53,10 @@ def subplot_arcs(arcs,subplot_index=111,title=None,full=True,label=True,dots=Tru
   draw_circle_arcs(arcs,label=label,dots=dots,jitter=jitter)
   ax.set_aspect('equal')
 
+# py.test doesn't seem to like running C++ functions directly (no __name__ property) so we have a wrapper here
+def test_circle_arc_area():
+  circle_arc_area_test()
+
 def test_circle_reverse():
   random.seed(1240405)
   for k in [2,3,4,10,100]:
@@ -66,6 +70,7 @@ def test_circle_reverse():
 def test_circle_quantize():
   random_circle_quantize_test(12312) # Test quantization for complete circles
   random.seed(37130)
+  # TODO: This should be combined with check_circle_quantize
   arcs0 = random_circle_arcs(1,100)
   #arcs0 = random_circle_arcs(20,5)
   arcs1 = circle_arc_quantize_test(arcs0)
@@ -84,7 +89,6 @@ def test_circle_quantize():
     subplot_arcs(arcs0, 121, "Before Quantization", **plot_args)
     subplot_arcs(arcs1, 122, "After Quantization", **plot_args)
     pylab.show()
-
 
   assert ex<1e-6 and eq<3e-5 #This threshold is pretty agressive and might not work for many seeds
 
@@ -196,65 +200,210 @@ def test_single_circle(show_results=False):
         subplot_arcs(overlap_arcs, 122, "Output of overlaps", **plot_args)
         pylab.show()
 
+# Compute t such that offset_arcs(arcs,-(t+tolerance/2)) will be empty and offset_arcs(arcs,-(t-tolerance/2) will not
+def find_thickness(arcs, tolerance):
+  if len(arcs) == 0:
+    return 0.
+  t_hi = 1.
+  while len(offset_arcs(arcs, -t_hi)) > 0:
+    t_hi *= 2.
+  t_lo = 0.
+  while abs(t_hi - t_lo) > tolerance:
+    t = 0.5*(t_lo+t_hi)
+    if len(offset_arcs(arcs, -t)) == 0:
+      t_hi = t
+    else:
+      t_lo = t
+    # These checks are commented out because they are expensive, but they should always be true inside this loop:
+    # assert len(offset_arcs(arcs, -t_hi)) == 0
+    # assert len(offset_arcs(arcs, -t_lo)) > 0
+  return 0.5*(t_lo + t_hi)
 
-def test_offsets():
-  random.seed(441424)
-  arcs0 = circle_arc_union(random_circle_arcs(10,10))
+def check_offset_error(arcs):
+  quantization_unit = circle_arc_quantization_unit(arcs)
+  # Offset should introduce errors bounded by a small constant number of quantization unit plus some floating point rounding errors
+  # I think the guaranteed error bound is probably higher than this, but I haven't found a test case where this fails
+  error_per_offset = 5.*quantization_unit
 
+  def thickness_ok(arcs, expected, max_error):
+    thickness_lo = expected - max_error
+    thickness_hi = expected + max_error
+    return len(offset_arcs(arcs, -thickness_lo)) > 0 \
+     and len(offset_arcs(arcs, -thickness_hi)) == 0
+
+  # Find starting thickness
+  starting_thickness = find_thickness(arcs,quantization_unit)
+  # Offset inward by a random 
+  delta = -starting_thickness*random.uniform(0.1,0.9)
+  new_arcs = offset_arcs(arcs,delta)
+
+  expected_new_thickness = starting_thickness + delta
+  if not thickness_ok(new_arcs, expected_new_thickness, error_per_offset):
+    new_thickness = find_thickness(new_arcs, quantization_unit)
+    error = abs(new_thickness - expected_new_thickness)
+    print "Starting thickness:",starting_thickness
+    print "New thickness:",new_thickness
+    print "Expected new thickness:",expected_new_thickness
+    error_msg = "For delta of %s, resulting error = %s (%s quantization units)" % (delta, error, error/quantization_unit)
+    if 0:
+      import pylab
+      pylab.suptitle(error_msg)
+      subplot_arcs(arcs, 121, "Initial", full=False)
+      subplot_arcs(new_arcs, 122, "Offset", full=False)
+      pylab.show()
+    assert False
+
+def fuzzy_arcs_equal(arcs0, arcs1, allowed_error_multiplier):
+  # Compare two sets of arcs that should be roughly the same shape up to noise introduced by quantization and inexact constructions
+  # allowed_error_multiplier should be in units of round trip error for quantization->offset->unquantization
+  # Actual errors appear to be substantially higher than expected in many cases and I'm not sure why!
+  combined = Nested.concatenate(arcs0, arcs1)
+  quantization_scale = circle_arc_quantization_unit(combined)
+  error_per_opp = quantization_scale*(circle_arc_max_quantization_error_guess()+circle_arc_max_offset_error_guess())
+  # xor arcs to get difference
+  delta = split_arcs_by_parity(combined)
+  # We might have thin features around edges, but a small negative offset should erase everything
+  max_error = (allowed_error_multiplier+1)*error_per_opp
+  squeezed_delta = offset_arcs(delta,-max_error) # Add additional margin for error during offsetting
+  similar = (len(squeezed_delta) == 0)
+  area_error = abs(circle_arc_area(arcs0) - circle_arc_area(arcs1))
+  # Sanity check that similar arcs have similar area
+  # In theory area_error tolerance should grow proportional to max_error*arcs_perimeter_length, but a constant works for current usage
+  if similar and not area_error < 3e-5:
+    if 0:
+      import pylab
+      pylab.suptitle("area_error: %s" % area_error)
+      subplot_arcs(combined, 121, "Combined", full=False)
+      subplot_arcs(delta, 122, "delta", full=False)
+      pylab.show()
+    assert False
+  return similar
+
+def check_positive_offsets(test_arcs, shell_delta=0.2, num_shells=5):
+  assert circle_arc_area(test_arcs) > 0 # These tests assume we start with a positive shape
+  assert shell_delta > 0 # These tests assume positive offsets
   print "Offsetting arcs"
-  arcs1 = offset_arcs(arcs0, 0.1)
-  assert circle_arc_area(arcs1) > circle_arc_area(arcs0)
+  # Test a single outward offset
+  outward_arcs = offset_arcs(test_arcs, 0.5*shell_delta)
+  assert circle_arc_area(outward_arcs) > circle_arc_area(test_arcs)
 
   print "Offsetting arcs with shells"
-  shells = offset_shells(arcs0, 0.2, 10)
-  # Check that we have monatonically increasing area
+  shells = offset_shells(test_arcs, shell_delta, num_shells)
+  assert num_shells == len(shells) # For positive input arcs and offset we should always get back requested number of shells
+  shells = [(shells[i], shell_delta*(i+1)) for i in range(len(shells))] # Zip shells and offsets
   prev_area, prev_arcs = 0, []
-  for arcs in [arcs0, arcs1] + shells:
-    area = circle_arc_area(arcs)
-
-    if not area > prev_area:
+  for shell,offset_d in [(test_arcs,0.), (outward_arcs,0.5*shell_delta)] + shells:
+    area = circle_arc_area(shell)
+    if not (area > prev_area):
       error = "Positive offset caused decrease in area from %g to %g" % (prev_area, area)
       print error
-      if 0:
+      if 0: # Enable this to visualize arcs
         import pylab
         pylab.suptitle(error)
         subplot_arcs(prev_arcs, 121, "Previous shell", full=False)
-        subplot_arcs(arcs, 122, "After offset", full=False)
+        subplot_arcs(shell, 122, "After offset", full=False)
         pylab.show()
       assert False
-    prev_area, prev_arcs = area, arcs
+    if offset_d >= shell_delta:
+      # Offset of the same distance starting at test_arcs should be almost exactly the same result
+      single_step_offset = offset_arcs(test_arcs, offset_d)
+      shell_steps = offset_d / shell_delta
+      quantization_unit = circle_arc_quantization_unit(shell)
 
-  print "Offsetting of open arcs"
-  arcs4 = offset_open_arcs(arcs0, 0.001) # Mostly this just ensures we don't hit any asserts
-  assert circle_arc_area(arcs4) > 0 # We should at least have a positive area
+      # This check fails in some cases and I'm not sure why!
+      if not fuzzy_arcs_equal(shell, single_step_offset, shell_steps + 1):
+        combined = Nested.concatenate(shell,single_step_offset)
+        delta = split_arcs_by_parity(combined)
+        quantization_unit = circle_arc_quantization_unit(combined)
+        t = find_thickness(delta, quantization_unit)
+        print "Error size: %s (%s quantization units)" % (t, t/quantization_unit)
+        if 0: # Enable this to visualize arcs
+          import pylab
+          pylab.suptitle("Area difference: %s" % abs(circle_arc_area(shell)-circle_arc_area(single_step_offset)))
+          subplot_arcs(test_arcs, 131, "Base Input", full=False)
+          subplot_arcs(shell, 132, "Shell based offset", full=False)
+          subplot_arcs(single_step_offset, 133, "Direct offset", full=False)
+          pylab.figure()
+          subplot_arcs(delta, 121, "Delta", full=False)
+          subplot_arcs(offset_arcs(delta,-quantization_unit*5*(shell_steps+1)), 122, "Bad Delta", full=False)
+          pylab.show()
+        assert False
+    prev_area, prev_arcs = area, shell
 
-def test_negative_offsets(seed=7056389):
-  print "Testing negative offset"
-  random.seed(seed)
+  print "Offsetting open arcs"
+  open_offset = offset_open_arcs(test_arcs, 0.001) # Mostly this just ensures we don't hit any asserts
+  assert circle_arc_area(open_offset) > 0 # We should at least have a positive area
+  total_offset = 0
+
+def test_positive_offsets():
+  # Check that offset of empty arcs is empty
+  empty_arcs = to_arcs([[]])
+  assert len(offset_arcs(empty_arcs, 1.)) == 0
+
+  unit_circle = to_arcs([[((1.,0.),1.),((-1.,0.),1.)]]) # Unit circle
+  check_positive_offsets(unit_circle)
+
+  random.seed(44122)
+  arcs0 = circle_arc_union(random_circle_arcs(10,10))
+  check_positive_offsets(arcs0)
+
+def check_negative_offsets(test_arcs):
   d = 0.4
   # Offset inward then outward would normally erode sharp features, but we can use a positive offset to generate a shape with no sharp features
-  arcs0 = offset_arcs(random_circle_arcs(10,10), d*1.5) # Generate random arcs and ensure features big enough to not disappear if we inset/offset again
-  inset = offset_arcs(arcs0, -d)
+  outer = offset_arcs(test_arcs, d*1.5) # Ensure features big enough to not disappear if we inset/offset again
+  inset = offset_arcs(outer, -d)
   reset = offset_arcs(inset, d)
-  arcs0_area = circle_arc_area(arcs0)
+  outer_area = circle_arc_area(outer)
   inset_area = circle_arc_area(inset)
   reset_area = circle_arc_area(reset)
-  assert inset_area < arcs0_area # Offset by negative amount should reduce area
-  area_error = abs(arcs0_area - reset_area)
-  assert area_error < 2e-6
-  # xor input arcs and result after inset/offset to get difference
-  delta = split_arcs_by_parity(Nested.concatenate(arcs0,reset))
-  # We expect thin features around edges of input arcs, but a small negative offset should erase everything
-  squeezed_delta = offset_arcs(delta,-1e-6)
-  assert len(squeezed_delta) == 0
-
+  assert inset_area < outer_area # Offset by negative amount should reduce area
+  if not fuzzy_arcs_equal(outer, reset, 2):
+    if 0:
+      import pylab
+      area_error = abs(outer_area - reset_area)
+      pylab.suptitle("Offset: %s, Area error:%s" % (sub_d, area_error))
+      print "outer_area:",outer_area
+      print "inset_area:",inset_area
+      print "reset_area:",reset_area
+      subplot_arcs(outer, 131, "outer", full=False)
+      subplot_arcs(inset, 132, "inset", full=False)
+      subplot_arcs(reset, 133, "reset", full=False)
+      pylab.show()
+    assert False
   # Check that a large negative offset leaves nothing
-  empty_arcs = offset_arcs(random_circle_arcs(10,10), -100.)
+  empty_arcs = offset_arcs(test_arcs, -100.)
   assert len(empty_arcs) == 0
 
+def test_negative_offsets(seed=7056389):
+  random.seed(seed)
+  check_negative_offsets(random_circle_arcs(10,10)) # Test on some random arcs
+  
+  unit_circle = to_arcs([[((1.,0.),1.),((-1.,0.),1.)]]) # Unit circle
+  check_negative_offsets(unit_circle)
+
+# Endlessly test offset code for different pseudo-random circle arcs
+def fuzz_offsets():
+  # Start with an actually random seed so that multiple tests aren't redundant
+  random.seed()
+  seed = random.randint(0,2<<30)
+  while True:
+    # Put our random sequence in an easy to recreate state
+    print "Testing with seed",seed
+    random.seed(seed)
+    # This would benefit from a smarter version of random_circle_arcs that generates more special cases (full circles, straight lines, etc)
+    raw_random_arcs = random_circle_arcs(10,10)
+    check_circle_quantize(raw_random_arcs)
+    random_arcs = circle_arc_union(raw_random_arcs)
+    check_positive_offsets(random_arcs)
+    check_negative_offsets(random_arcs)
+    check_offset_error(random_arcs)
+    check_circle_quantize(random_arcs)
+    seed += 1
+
 if __name__=='__main__':
-  test_offsets()
+  test_positive_offsets()
   test_negative_offsets()
   test_circle_quantize()
   test_single_circle()
   test_circles()
+  fuzz_offsets()


### PR DESCRIPTION
Fix some bugs in circle_arc_area, arc unquantization, and arc offsets. Improve unit tests to prevent similar errors in the future

* Fix error in ArcDirection operator- which had broken negative offset of full circles
* Fix divide by two error in circle_arc_area
* Change computation of q in arc unquantization to reduce worst case error
* Cleanup redundant values in circle_offsets.cpp:add_capsule_helper
* Add printing operators for debugging
* Add unit test for circle_arc_area
* Add approximate error bounds for arc quantization and offsets for use in testing
* Add additional circle quantization check
* Improve unit tests for arc offset
* Add fuzz testing function for arc quantization and offsets
